### PR TITLE
Add RcppParallel cxxflags to makevars

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -1,4 +1,5 @@
 PKG_CXXFLAGS += -DRCPP_USE_UNWIND_PROTECT
+KG_CXXFLAGS += $(shell ${R_HOME}/bin/Rscript -e "RcppParallel::CxxFlags()")
 
 # Needed due to RcppArmadillo
 PKG_LIBS += $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,5 +1,5 @@
 PKG_CXXFLAGS += -DRCPP_USE_UNWIND_PROTECT
-KG_CXXFLAGS += $(shell ${R_HOME}/bin/Rscript -e "RcppParallel::CxxFlags()")
+PKG_CXXFLAGS += $(shell ${R_HOME}/bin/Rscript -e "RcppParallel::CxxFlags()")
 
 # Needed due to RcppArmadillo
 PKG_LIBS += $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,3 @@
-PKG_CXXFLAGS += -DRCPP_PARALLEL_USE_TBB=1
 PKG_CXXFLAGS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "RcppParallel::CxxFlags()")
 
 # Needed due to RcppArmadillo

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,5 @@
 PKG_CXXFLAGS += -DRCPP_PARALLEL_USE_TBB=1
+PKG_CXXFLAGS += $(shell "${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" -e "RcppParallel::CxxFlags()")
 
 # Needed due to RcppArmadillo
 PKG_LIBS += $(LAPACK_LIBS) $(BLAS_LIBS) $(FLIBS)


### PR DESCRIPTION
This PR updates your Makevars to add RcppParallel's CXXFLAGS, which will be needed for compatibility with Windows ARM64
